### PR TITLE
Changed the $app argument required by LaravelCoinpayments to optional

### DIFF
--- a/src/Kevupton/LaravelCoinpayments/LaravelCoinpayments.php
+++ b/src/Kevupton/LaravelCoinpayments/LaravelCoinpayments.php
@@ -35,7 +35,7 @@ class LaravelCoinpayments extends Coinpayments
 
     private $app;
 
-    public function __construct ($app)
+    public function __construct ($app = null)
     {
         $this->app = $app;
 


### PR DESCRIPTION
Change the $app argument required by LaravelCoinpayments to optional because the app service container blows up on dependency injection or dependency resolve with the following error :
    ` "message": "Unresolvable dependency resolving [Parameter #0 [ <required> $app ]] in class Kevupton\\LaravelCoinpayments\\LaravelCoinpayments",
    "exception": "Illuminate\\Contracts\\Container\\BindingResolutionException",
    "file": "/home/saviobosco/Desktop/laravel-Apps/henry-crypto/vendor/laravel/framework/src/Illuminate/Container/Container.php",
    "line": 948, `