### PR TITLE
Make cp_callback_addresses.address field unique

### DIFF
--- a/src/database/migrations/2018_03_24_032432_create_callback_address_table.php
+++ b/src/database/migrations/2018_03_24_032432_create_callback_address_table.php
@@ -17,12 +17,11 @@ class CreateCallbackAddressTable extends Migration
 
         Schema::create($prefix . 'callback_addresses', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('address', 128);
+            $table->string('address', 128)->unique();
             $table->string('currency', 10);
             $table->text('pubkey')->nullable();
             $table->string('ipn_url')->nullable();
             $table->string('dest_tag')->nullable();
-            $table->unique(['address', 'currency']);
             $table->timestamps();
         });
 


### PR DESCRIPTION
Fixes an issue with database migrations when using Postgres.

Postgres enforces `unique` on referenced foreign key fields.